### PR TITLE
Change tasks page to be a calendar

### DIFF
--- a/lib/skool/converter.ex
+++ b/lib/skool/converter.ex
@@ -1,0 +1,4 @@
+defmodule Skool.Converter do
+  def to_ingeter(value) when is_binary(value), do: String.to_integer(value)
+  def to_ingeter(value) when is_integer(value), do: value
+end

--- a/lib/skool/courses.ex
+++ b/lib/skool/courses.ex
@@ -57,6 +57,7 @@ defmodule Skool.Courses do
     |> or_where([c, cc], c.created_by_id == ^user.id and is_nil(c.deleted_at))
     |> select([course, _course_collaborator, enrollment], %Course{
       id: course.id,
+      color: course.color,
       name: course.name,
       start_date: course.start_date,
       end_date: course.end_date,

--- a/lib/skool/courses/course.ex
+++ b/lib/skool/courses/course.ex
@@ -14,6 +14,7 @@ defmodule Skool.Courses.Course do
     field :end_date, :date
     field :deleted_at, :utc_datetime
     field :finalized_at, :utc_datetime
+    field :color, :string, default: "#7752fe"
 
     has_many :assignments, Assignment
 
@@ -37,6 +38,7 @@ defmodule Skool.Courses.Course do
     course
     |> cast(attrs, [
       :name,
+      :color,
       :description,
       :category,
       :start_date,
@@ -44,6 +46,6 @@ defmodule Skool.Courses.Course do
       :created_by_id,
       :finalized_at
     ])
-    |> validate_required([:name, :start_date, :end_date, :created_by_id])
+    |> validate_required([:name, :color, :start_date, :end_date, :created_by_id])
   end
 end

--- a/lib/skool/date_helpers.ex
+++ b/lib/skool/date_helpers.ex
@@ -11,4 +11,39 @@ defmodule Skool.DateHelpers do
     |> DateTime.shift_zone!(user.preferred_timezone, Tz.TimeZoneDatabase)
     |> DateTime.to_date()
   end
+
+  @doc """
+  This function is used for building the calendar grid.
+
+  Given row and column indexes in the calendar grid and the day of the week
+  for the first of the month, determine the day of the month that should go
+  in that cell.
+
+  ## Assumptions
+
+  - The row and column indexes are 0-based.
+  - The day of the week for the first of the month is 1-based, with 1 being
+    Sunday and 7 being Saturday. See `Date.day_of_week/1` for more information.
+    So in November 2024, for example, the first of the month is a Friday, so
+    `first_of_month_day_of_week` would be 6.
+
+  ## Examples
+
+        iex> day_of_month(0, 0, 1)
+        1
+        iex> day_of_month(1, 0, 1)
+        8
+        iex> day_of_month(0, 5, 6)
+        1
+        iex> day_of_month(0, 4, 6)
+        -1
+  """
+  @spec day_of_month(integer(), integer(), integer()) :: integer()
+  def day_of_month(0, column, first_of_month_day_of_week) do
+    column - first_of_month_day_of_week + 2
+  end
+
+  def day_of_month(row, column, first_of_month_day_of_week) do
+    day_of_month(0, column, first_of_month_day_of_week) + row * 7
+  end
 end

--- a/lib/skool_web/html_helpers.ex
+++ b/lib/skool_web/html_helpers.ex
@@ -15,6 +15,23 @@ defmodule SkoolWeb.HTMLHelpers do
     end
   end
 
+  def month_name(month) when is_integer(month) do
+    case month do
+      1 -> "January"
+      2 -> "February"
+      3 -> "March"
+      4 -> "April"
+      5 -> "May"
+      6 -> "June"
+      7 -> "July"
+      8 -> "August"
+      9 -> "September"
+      10 -> "October"
+      11 -> "November"
+      12 -> "December"
+    end
+  end
+
   def display_repeats(%Assignment{kind: kind}) when kind != :recurring,
     do: ""
 

--- a/lib/skool_web/live/course_live/edit.ex
+++ b/lib/skool_web/live/course_live/edit.ex
@@ -20,6 +20,7 @@ defmodule SkoolWeb.CourseLive.Edit do
             <.input type="date" field={@form[:start_date]} label="Start Date" />
             <.input type="date" field={@form[:end_date]} label="End Date" />
           </div>
+          <.input type="color" field={@form[:color]} label="Color" />
           <.input type="textarea" field={@form[:description]} label="Description" />
         </.form>
       </div>

--- a/lib/skool_web/live/course_live/index.ex
+++ b/lib/skool_web/live/course_live/index.ex
@@ -21,7 +21,11 @@ defmodule SkoolWeb.CourseLive.Index do
           rows={@streams.courses}
           row_click={fn {_id, course} -> JS.navigate(~p"/courses/#{course.id}") end}
         >
-          <:col :let={{_id, course}} label="Name"><%= course.name %></:col>
+          <:col :let={{_id, course}} label="Name">
+            <div class="grid grid-cols-[1rem_1fr] gap-3 items-center">
+              <div class="rounded-full w-4 h-4" style={"background: #{course.color}"} /><%= course.name %>
+            </div>
+          </:col>
           <:col :let={{_id, course}} label="Start Date"><%= format_date(course.start_date) %></:col>
           <:col :let={{_id, course}} label="End Date"><%= format_date(course.end_date) %></:col>
           <:col :let={{_id, course}} label="Status">

--- a/lib/skool_web/live/course_live/new.ex
+++ b/lib/skool_web/live/course_live/new.ex
@@ -19,6 +19,7 @@ defmodule SkoolWeb.CourseLive.New do
             <.input type="date" field={@form[:start_date]} label="Start Date" />
             <.input type="date" field={@form[:end_date]} label="End Date" />
           </div>
+          <.input type="color" field={@form[:color]} label="Color" />
         </.form>
       </div>
       <.footer>

--- a/lib/skool_web/live/tasks_live/index.ex
+++ b/lib/skool_web/live/tasks_live/index.ex
@@ -1,7 +1,7 @@
 defmodule SkoolWeb.TasksLive.Index do
-  use SkoolWeb, :live_view
-
   alias Skool.{DateHelpers, Tasks}
+
+  use SkoolWeb, :live_view
 
   @impl true
   def render(assigns) do
@@ -11,34 +11,34 @@ defmodule SkoolWeb.TasksLive.Index do
         Tasks
       </.header>
       <div class="p-4">
-        <h1>Due Today (<%= format_date(@todays_date) %>)</h1>
-        <.table id="todays_tasks" rows={@streams.todays_tasks}>
-          <:col :let={{_id, task}} label="Name"><.task_name task={task} /></:col>
-          <:col :let={{_id, task}} label="Course"><%= task.assignment.course.name %></:col>
-          <:action :let={{_id, task}}>
-            <%= if is_nil(task.completed_at) do %>
-              <button phx-click="complete" phx-value-task_id={task.id}>Complete Task</button>
-            <% else %>
-              <.icon name="hero-check-circle" class="text-secondary" />
+        <div id="calendar-root">
+          <div id="calendar-header" class="pb-4 flex gap-4">
+            <div>
+              <button class="mr-2" phx-click="prev_month">&larr;</button>
+              <button phx-click="next_month">&rarr;</button>
+            </div>
+            <h1 class="font-bold"><%= month_name(@current_month) %> <%= @current_year %></h1>
+          </div>
+          <div id="calendar-day-labels" class="flex">
+            <%= for day <- ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] do %>
+              <p class="flex-1 text-center"><%= day %></p>
             <% end %>
-          </:action>
-        </.table>
-      </div>
-
-      <div class="p-4">
-        <h1>Due this week</h1>
-        <.table id="week_tasks" rows={@streams.week_tasks}>
-          <:col :let={{_id, task}} label="Name"><.task_name task={task} /></:col>
-          <:col :let={{_id, task}} label="Due Date"><%= format_date(task.due_date) %></:col>
-          <:col :let={{_id, task}} label="Course"><%= task.assignment.course.name %></:col>
-          <:action :let={{_id, task}}>
-            <%= if is_nil(task.completed_at) do %>
-              <button phx-click="complete" phx-value-task_id={task.id}>Complete Task</button>
-            <% else %>
-              <.icon name="hero-check-circle" class="text-secondary" />
+          </div>
+          <div class="grid grid-cols-7">
+            <%= for row <- 0..(number_of_rows(@days_in_month, @first_of_month_day_of_week) - 1) do %>
+              <%= for column <- 0..6 do %>
+                <.calendar_day
+                  current_year={@current_year}
+                  current_month={@current_month}
+                  day_of_month={DateHelpers.day_of_month(row, column, @first_of_month_day_of_week)}
+                  days_in_month={@days_in_month}
+                  tasks={@tasks}
+                  todays_date={@todays_date}
+                />
+              <% end %>
             <% end %>
-          </:action>
-        </.table>
+          </div>
+        </div>
       </div>
     </div>
     """
@@ -49,17 +49,42 @@ defmodule SkoolWeb.TasksLive.Index do
     {:ok,
      socket
      |> assign_todays_date()
-     |> stream_tasks()
-     |> stream_week_tasks()
      |> assign(:active_tab, :tasks)
      |> assign(:page_title, "Tasks")}
   end
 
   @impl true
-  def handle_event("complete", %{"task_id" => id}, socket) do
-    {:ok, _} = Tasks.complete_task(id)
+  def handle_params(params, _uri, socket) do
+    [year, month] = current_month_year(socket, params)
 
-    {:noreply, socket |> stream_tasks() |> stream_week_tasks()}
+    first_of_month = Date.new!(year, month, 1)
+
+    {:noreply,
+     socket
+     |> assign(:params, params)
+     |> assign(:current_month, month)
+     |> assign(:current_year, year)
+     |> assign(
+       :first_of_month_day_of_week,
+       Date.day_of_week(first_of_month, :sunday)
+     )
+     |> assign(:days_in_month, Date.days_in_month(first_of_month))
+     |> assign_tasks()}
+  end
+
+  @impl true
+  def handle_event("toggle_complete", %{"task_id" => id}, socket) do
+    {:ok, _} = Tasks.toggle_completed_at(id)
+
+    {:noreply, assign_tasks(socket)}
+  end
+
+  def handle_event("next_month", _payload, socket) do
+    {:noreply, socket |> push_patch(to: ~p"/tasks?month=#{next_month(socket)}")}
+  end
+
+  def handle_event("prev_month", _payload, socket) do
+    {:noreply, socket |> push_patch(to: ~p"/tasks?month=#{prev_month(socket)}")}
   end
 
   defp assign_todays_date(socket) do
@@ -67,35 +92,83 @@ defmodule SkoolWeb.TasksLive.Index do
     assign(socket, todays_date: date)
   end
 
-  defp stream_tasks(socket) do
-    stream(
-      socket,
-      :todays_tasks,
-      Tasks.list_tasks_for_date(socket.assigns.current_user, socket.assigns.todays_date)
-    )
+  defp assign_tasks(socket) do
+    tasks =
+      socket.assigns.current_year
+      |> Tasks.tasks_for_month(socket.assigns.current_month)
+      |> Enum.group_by(& &1.due_date.day)
+
+    assign(socket, tasks: tasks)
   end
 
-  defp stream_week_tasks(socket) do
-    stream(
-      socket,
-      :week_tasks,
-      Tasks.list_tasks_for_week(socket.assigns.current_user, socket.assigns.todays_date)
-    )
+  defp next_month(socket) do
+    [year, month] = current_month_year(socket)
+
+    case month do
+      12 -> "#{year + 1}-1"
+      _ -> "#{year}-#{month + 1}"
+    end
   end
 
-  defp task_name(%{task: %Tasks.Task{checklist_item: checklist_item}} = assigns)
-       when not is_nil(checklist_item) do
+  defp prev_month(socket) do
+    [year, month] = current_month_year(socket)
+
+    case month do
+      1 -> "#{year - 1}-12"
+      _ -> "#{year}-#{month - 1}"
+    end
+  end
+
+  defp current_month_year(socket, params \\ nil) do
+    today = DateHelpers.today(socket.assigns.current_user)
+
+    params = params || Map.get(socket.assigns, :params)
+
+    params
+    |> Map.get("month", "#{today.year}-#{today.month}")
+    |> String.split("-")
+    |> Enum.map(&String.to_integer/1)
+  end
+
+  defp calendar_day(assigns) do
     ~H"""
-    <p>
-      <%= @task.checklist_item.title %>
-      <span class="text-xs text-gray-500">(<%= @task.assignment.title %>)</span>
-    </p>
+    <div class="border border-gray-100 border-solid h-48 flex-1">
+      <div class="p-2 pt-1">
+        <%= if @day_of_month in 1..@days_in_month do %>
+          <div class="flex justify-center">
+            <p class={[
+              "text-sm text-gray-500 font-bold rounded-full h-8 w-8 p-1 flex flex-col justify-center text-center",
+              Date.compare(@todays_date, Date.new!(@current_year, @current_month, @day_of_month)) ==
+                :eq && "bg-gray-200"
+            ]}>
+              <%= @day_of_month %>
+            </p>
+          </div>
+          <div>
+            <%= for task <- Map.get(@tasks, @day_of_month, []) do %>
+              <button
+                phx-click="toggle_complete"
+                phx-value-task_id={task.id}
+                class="w-4 h-4 rounded-full group relative inline-block md:mx-[2px]"
+                style={"background: #{if is_nil(task.completed_at), do: task.color, else: "#ccc"}"}
+              >
+                <div class="hidden group-hover:block bg-gray-200 rounded-md w-fit py-1 px-2 bottom-6 left-[50%] translate-x-[-50%] absolute whitespace-nowrap">
+                  <%= task.title %>
+                </div>
+              </button>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    </div>
     """
   end
 
-  defp task_name(%{task: %Tasks.Task{}} = assigns) do
-    ~H"""
-    <p><%= @task.assignment.title %></p>
-    """
+  defp number_of_rows(days_in_month, first_of_month_day_of_week) do
+    days_in_first_week = 8 - first_of_month_day_of_week
+    remaining_days = days_in_month - days_in_first_week
+    full_weeks_after_first_week = div(remaining_days, 7)
+    additional_partial_weeks = if rem(remaining_days, 7) > 0, do: 1, else: 0
+    1 + full_weeks_after_first_week + additional_partial_weeks
   end
 end

--- a/priv/repo/migrations/20241116021806_add_color_to_courses.exs
+++ b/priv/repo/migrations/20241116021806_add_color_to_courses.exs
@@ -1,0 +1,9 @@
+defmodule Skool.Repo.Migrations.AddColorToCourses do
+  use Ecto.Migration
+
+  def change do
+    alter table(:courses) do
+      add :color, :string, default: "#7752fe"
+    end
+  end
+end


### PR DESCRIPTION
Instead of simple lists of tasks for today and this week, the '/tasks' page now shows a full month calendar. Each task shows up as a colored dot on the day it's due, with a tooltip on hover that displays the name of the associated checklist item (if it exists) or assignment.

The color for each task dot is determined by the 'color' column on the course the task is associated with. This is a new column which was created as part of this calendar view effort.

You can complete or uncomplete a task by clicking on its dot.

My intention with this effort is to make it easier to retroactively or proactively check off tasks. Last quarter, I realized that I don't check the app every day, even if I do have my tasks in mind. I stopped using the app, though, because there was no way to go back and check things off - once I got behind, I felt like the data was already inaccurate, so there was no point in continuing to use it. Another pain point is when I would finish tasks early, I had to wait until the due date arrived in order to check it off. The calendar view fixes all the pain points for me.